### PR TITLE
Use any Widget instead of Text widget for title, description

### DIFF
--- a/lib/elegant_notification.dart
+++ b/lib/elegant_notification.dart
@@ -338,11 +338,11 @@ class ElegantNotification extends StatefulWidget {
 
   ///The toast title if any
   ///
-  final Text? title;
+  final Widget? title;
 
   ///The toast description text (required)
   ///
-  final Text description;
+  final Widget description;
 
   ///The toast icon, required only if using the default constructor
   ///for other toast types (Success, Info, error) the icon is not changeable

--- a/lib/widgets/toast_content.dart
+++ b/lib/widgets/toast_content.dart
@@ -22,11 +22,11 @@ class ToastContent extends StatelessWidget {
 
   ///The title of the notification if any
   ///
-  final Text? title;
+  final Widget? title;
 
   ///The description of the notification text string
   ///
-  final Text description;
+  final Widget description;
 
   ///The notification icon
   final Widget? icon;
@@ -93,12 +93,12 @@ class ToastContent extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               if (title != null) ...[
-                title!.cloneTitle(),
+                title!,
                 const SizedBox(
                   height: 5,
                 ),
               ],
-              description.cloneDescription(),
+              description,
               if (action != null) ...[
                 const SizedBox(
                   height: 5,


### PR DESCRIPTION
Having `Text` widget hardcoded makes it not possible use `MarkdownBody` or `RichText` for the `title` and `description`. The package should be flexible enough to let developers use their own widgets maybe.