### PR TITLE
Added dismiss function and wrapped notification with Dismissible widget

### DIFF
--- a/lib/elegant_notification.dart
+++ b/lib/elegant_notification.dart
@@ -29,8 +29,6 @@ class ElegantNotification extends StatefulWidget {
     this.notificationPosition = NotificationPosition.topRight,
     this.position = Alignment.topRight,
     this.animation = AnimationType.fromRight,
-    this.dismissDirection = DismissDirection.horizontal,
-    this.isDismissible = true,
     this.animationDuration = const Duration(milliseconds: 600),
     this.iconSize = defaultIconSize,
     this.action,
@@ -64,8 +62,6 @@ class ElegantNotification extends StatefulWidget {
     this.notificationPosition = NotificationPosition.topRight,
     this.position = Alignment.topRight,
     this.animation = AnimationType.fromRight,
-    this.dismissDirection = DismissDirection.horizontal,
-    this.isDismissible = true,
     this.animationDuration = const Duration(milliseconds: 600),
     this.showProgressIndicator = true,
     this.action,
@@ -101,8 +97,6 @@ class ElegantNotification extends StatefulWidget {
     this.notificationPosition = NotificationPosition.topRight,
     this.position = Alignment.topRight,
     this.animation = AnimationType.fromRight,
-    this.dismissDirection = DismissDirection.horizontal,
-    this.isDismissible = true,
     this.animationDuration = const Duration(milliseconds: 600),
     this.showProgressIndicator = true,
     this.action,
@@ -138,8 +132,6 @@ class ElegantNotification extends StatefulWidget {
     this.notificationPosition = NotificationPosition.topRight,
     this.position = Alignment.topRight,
     this.animation = AnimationType.fromRight,
-    this.dismissDirection = DismissDirection.horizontal,
-    this.isDismissible = true,
     this.animationDuration = const Duration(milliseconds: 600),
     this.showProgressIndicator = true,
     this.action,
@@ -337,14 +329,6 @@ class ElegantNotification extends StatefulWidget {
   final NotificationPosition notificationPosition;
   final Alignment position;
 
-  ///define whether the notification will be dismissible or not
-  ///by default `isDismissible == true`
-  final bool isDismissible;
-
-  ///The direction of the dismiss action
-  ///by default `dismissDirection == DismissDirection.horizontal`
-  final DismissDirection dismissDirection;
-
   ///Action widget rendered with clickable inkwell
   ///by default `action == null`
   final Widget? action;
@@ -409,7 +393,6 @@ class ElegantNotification extends StatefulWidget {
   late AnimationController _slideController;
 
   OverlayEntry _overlayEntryBuilder() {
-    final dismissibleKey = UniqueKey();
     return OverlayEntry(
       opaque: false,
       builder: (context) {
@@ -420,18 +403,7 @@ class ElegantNotification extends StatefulWidget {
             contentPadding: const EdgeInsets.all(0),
             insetPadding: const EdgeInsets.all(30),
             elevation: 0,
-            content: isDismissible
-                ? Dismissible(
-                    key: dismissibleKey,
-                    direction: dismissDirection,
-                    onDismissed: (direction) {
-                      _closeTimer.cancel();
-                      onDismiss?.call();
-                      closeOverlay();
-                    },
-                    child: this,
-                  )
-                : this,
+            content: this,
           ),
         );
       },
@@ -532,16 +504,8 @@ class ElegantNotificationState extends State<ElegantNotification>
 
   void closeNotification() {
     widget.onCloseButtonPressed?.call();
-    closeTimer.cancel();
-    slideController.reverse();
-    widget.onDismiss?.call();
-    widget.closeOverlay();
-  }
-
-  void closeNotification() {
-    widget.onCloseButtonPressed?.call();
-    closeTimer.cancel();
-    slideController.reverse();
+    widget._closeTimer.cancel();
+    widget._slideController.reverse();
     widget.onDismiss?.call();
     widget.closeOverlay();
   }
@@ -549,7 +513,7 @@ class ElegantNotificationState extends State<ElegantNotification>
   @override
   Widget build(BuildContext context) {
     return SlideTransition(
-      position: offsetAnimation,
+      position: widget._offsetAnimation,
       child: InkWell(
         onTap: widget.onTap == null
             ? null

--- a/lib/elegant_notification.dart
+++ b/lib/elegant_notification.dart
@@ -40,6 +40,8 @@ class ElegantNotification extends StatefulWidget {
     this.progressBarWidth,
     this.progressBarPadding,
     this.onDismiss,
+    this.isDismissible = true,
+    this.dismissDirection = DismissDirection.horizontal,
     this.progressIndicatorBackground = greyColor,
     this.onTap,
     this.closeOnTap = false,
@@ -73,6 +75,8 @@ class ElegantNotification extends StatefulWidget {
     this.progressBarWidth,
     this.progressBarPadding,
     this.onDismiss,
+    this.isDismissible = true,
+    this.dismissDirection = DismissDirection.horizontal,
     this.progressIndicatorBackground = greyColor,
     this.onTap,
     this.closeOnTap = false,
@@ -108,6 +112,8 @@ class ElegantNotification extends StatefulWidget {
     this.progressBarWidth,
     this.progressBarPadding,
     this.onDismiss,
+    this.isDismissible = true,
+    this.dismissDirection = DismissDirection.horizontal,
     this.progressIndicatorBackground = greyColor,
     this.onTap,
     this.closeOnTap = false,
@@ -143,6 +149,8 @@ class ElegantNotification extends StatefulWidget {
     this.progressBarWidth,
     this.progressBarPadding,
     this.onDismiss,
+    this.isDismissible = true,
+    this.dismissDirection = DismissDirection.horizontal,
     this.progressIndicatorBackground = greyColor,
     this.onTap,
     this.closeOnTap = false,
@@ -361,6 +369,14 @@ class ElegantNotification extends StatefulWidget {
   ///or when tapping on the screen
   final Function()? onDismiss;
 
+  ///The direction of the dismissible widget
+  ///by default it's `DismissDirection.horizontal`
+  final DismissDirection dismissDirection;
+
+  ///If the notification is dismissible or not
+  ///by default it's true
+  final bool isDismissible;
+
   //Overlay that does not block the screen
   OverlayEntry? overlayEntry;
 
@@ -393,6 +409,7 @@ class ElegantNotification extends StatefulWidget {
   late AnimationController _slideController;
 
   OverlayEntry _overlayEntryBuilder() {
+    final dismissibleKey = UniqueKey();
     return OverlayEntry(
       opaque: false,
       builder: (context) {
@@ -403,7 +420,18 @@ class ElegantNotification extends StatefulWidget {
             contentPadding: const EdgeInsets.all(0),
             insetPadding: const EdgeInsets.all(30),
             elevation: 0,
-            content: this,
+            content: isDismissible
+                ? Dismissible(
+                    key: dismissibleKey,
+                    direction: dismissDirection,
+                    onDismissed: (direction) {
+                      _closeTimer.cancel();
+                      onDismiss?.call();
+                      closeOverlay();
+                    },
+                    child: this,
+                  )
+                : this,
           ),
         );
       },

--- a/lib/elegant_notification.dart
+++ b/lib/elegant_notification.dart
@@ -384,6 +384,10 @@ class ElegantNotification extends StatefulWidget {
   ///by default it's grey
   final Color progressIndicatorBackground;
 
+  late Timer _closeTimer;
+  late Animation<Offset> _offsetAnimation;
+  late AnimationController _slideController;
+
   ///display the notification on the screen
   ///[context] the context of the application
   void show(BuildContext context) {
@@ -403,10 +407,6 @@ class ElegantNotification extends StatefulWidget {
       closeOverlay();
     });
   }
-
-  late Timer _closeTimer;
-  late Animation<Offset> _offsetAnimation;
-  late AnimationController _slideController;
 
   OverlayEntry _overlayEntryBuilder() {
     final dismissibleKey = UniqueKey();

--- a/lib/elegant_notification.dart
+++ b/lib/elegant_notification.dart
@@ -29,6 +29,8 @@ class ElegantNotification extends StatefulWidget {
     this.notificationPosition = NotificationPosition.topRight,
     this.position = Alignment.topRight,
     this.animation = AnimationType.fromRight,
+    this.dismissDirection = DismissDirection.horizontal,
+    this.isDismissible = true,
     this.animationDuration = const Duration(milliseconds: 600),
     this.iconSize = defaultIconSize,
     this.action,
@@ -62,6 +64,8 @@ class ElegantNotification extends StatefulWidget {
     this.notificationPosition = NotificationPosition.topRight,
     this.position = Alignment.topRight,
     this.animation = AnimationType.fromRight,
+    this.dismissDirection = DismissDirection.horizontal,
+    this.isDismissible = true,
     this.animationDuration = const Duration(milliseconds: 600),
     this.showProgressIndicator = true,
     this.action,
@@ -97,6 +101,8 @@ class ElegantNotification extends StatefulWidget {
     this.notificationPosition = NotificationPosition.topRight,
     this.position = Alignment.topRight,
     this.animation = AnimationType.fromRight,
+    this.dismissDirection = DismissDirection.horizontal,
+    this.isDismissible = true,
     this.animationDuration = const Duration(milliseconds: 600),
     this.showProgressIndicator = true,
     this.action,
@@ -132,6 +138,8 @@ class ElegantNotification extends StatefulWidget {
     this.notificationPosition = NotificationPosition.topRight,
     this.position = Alignment.topRight,
     this.animation = AnimationType.fromRight,
+    this.dismissDirection = DismissDirection.horizontal,
+    this.isDismissible = true,
     this.animationDuration = const Duration(milliseconds: 600),
     this.showProgressIndicator = true,
     this.action,
@@ -329,6 +337,14 @@ class ElegantNotification extends StatefulWidget {
   final NotificationPosition notificationPosition;
   final Alignment position;
 
+  ///define whether the notification will be dismissible or not
+  ///by default `isDismissible == true`
+  final bool isDismissible;
+
+  ///The direction of the dismiss action
+  ///by default `dismissDirection == DismissDirection.horizontal`
+  final DismissDirection dismissDirection;
+
   ///Action widget rendered with clickable inkwell
   ///by default `action == null`
   final Widget? action;
@@ -393,6 +409,7 @@ class ElegantNotification extends StatefulWidget {
   late AnimationController _slideController;
 
   OverlayEntry _overlayEntryBuilder() {
+    final dismissibleKey = UniqueKey();
     return OverlayEntry(
       opaque: false,
       builder: (context) {
@@ -403,7 +420,16 @@ class ElegantNotification extends StatefulWidget {
             contentPadding: const EdgeInsets.all(0),
             insetPadding: const EdgeInsets.all(30),
             elevation: 0,
-            content: this,
+            content: Dismissible(
+              key: dismissibleKey,
+              direction: dismissDirection,
+              onDismissed: (direction) {
+                _closeTimer.cancel();
+                onDismiss?.call();
+                closeOverlay();
+              },
+              child: this,
+            ),
           ),
         );
       },

--- a/lib/elegant_notification.dart
+++ b/lib/elegant_notification.dart
@@ -420,16 +420,18 @@ class ElegantNotification extends StatefulWidget {
             contentPadding: const EdgeInsets.all(0),
             insetPadding: const EdgeInsets.all(30),
             elevation: 0,
-            content: Dismissible(
-              key: dismissibleKey,
-              direction: dismissDirection,
-              onDismissed: (direction) {
-                _closeTimer.cancel();
-                onDismiss?.call();
-                closeOverlay();
-              },
-              child: this,
-            ),
+            content: isDismissible
+                ? Dismissible(
+                    key: dismissibleKey,
+                    direction: dismissDirection,
+                    onDismissed: (direction) {
+                      _closeTimer.cancel();
+                      onDismiss?.call();
+                      closeOverlay();
+                    },
+                    child: this,
+                  )
+                : this,
           ),
         );
       },


### PR DESCRIPTION
Dismiss function is called when closing the notification to remove it smoothly calling the reverse animation action. Dismissible Widget wrapped the ElegantNotification widget to allow swipe to dismiss action as per #107 