### PR TITLE
Fix stacked notifications not showing properly

### DIFF
--- a/lib/elegant_notification.dart
+++ b/lib/elegant_notification.dart
@@ -397,6 +397,7 @@ class ElegantNotification extends StatefulWidget {
     } else {
       Navigator.of(context).overlay?.insert(overlayEntry!);
     }
+    overlayManager.addOverlay(internalKey, overlayEntry!);
   }
 
   void closeOverlay() {


### PR DESCRIPTION
The overlay manager was never having anything added to it, so the stack position would always remain -1, causing multiple notifications to not stack and instead pile up on each other